### PR TITLE
Removed incomplete multi-line comment and added the response code in error message

### DIFF
--- a/api.go
+++ b/api.go
@@ -27,7 +27,7 @@ func (tba Client) get(path string) ([]byte, error) {
 		return nil, err
 	}
 	if resp.StatusCode != 200 {
-		return nil, errors.New("response code not 200, response code is: " + fmt.Sprint(resp.StatusCode))
+		return nil, errors.New(fmt.Sprintf("response code not 200, response code is: %d", resp.StatusCode))
 	}
 	defer resp.Body.Close()
 	body, err := ioutil.ReadAll(resp.Body)

--- a/api.go
+++ b/api.go
@@ -3,6 +3,7 @@ package tbago
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 )
@@ -26,7 +27,7 @@ func (tba Client) get(path string) ([]byte, error) {
 		return nil, err
 	}
 	if resp.StatusCode != 200 {
-		return nil, errors.New("response code not 200")
+		return nil, errors.New("response code not 200, response code is: " + fmt.Sprint(resp.StatusCode))
 	}
 	defer resp.Body.Close()
 	body, err := ioutil.ReadAll(resp.Body)

--- a/api.go
+++ b/api.go
@@ -27,7 +27,7 @@ func (tba Client) get(path string) ([]byte, error) {
 		return nil, err
 	}
 	if resp.StatusCode != 200 {
-		return nil, errors.New(fmt.Sprintf("response code not 200, response code is: %d", resp.StatusCode))
+		return nil, errors.New(fmt.Sprintf("non-200 response code %d", resp.StatusCode))
 	}
 	defer resp.Body.Close()
 	body, err := ioutil.ReadAll(resp.Body)

--- a/example/main.go
+++ b/example/main.go
@@ -1,13 +1,14 @@
 package main
 
 import (
-	tbago "../../tbago"
 	"fmt"
 	"log"
+
+	tbago "../../tbago"
 )
 
 func main() {
-    tba, err := tbago.New("jVuUB9i97FgP8vVaCTCWFw5bjBmKyjG80nAs4nQhbS2G2xBVmIKvvE0lXnCeuciV")
+	tba, err := tbago.New("jVuUB9i97FgP8vVaCTCWFw5bjBmKyjG80nAs4nQhbS2G2xBVmIKvvE0lXnCeuciV")
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -35,5 +36,4 @@ func main() {
 		log.Fatal(err)
 	}
 	fmt.Println(vids)
-	*/
 }


### PR DESCRIPTION
An end point for a multi-line comment was left in main.go in the examples folder, so I removed it.  Also, for when you make the end point request and handle a non-200 status code, you did not give what the actual code was, which could help a developer in debugging their code, so I added that in to be a more descriptive error message.