### PR TITLE
Support Go Modules

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/frc1418/tbago
 
-go 1.17
+go 1.16

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/frc1418/tbago
+
+go 1.17


### PR DESCRIPTION
Go Modules were introduced in 1.11 as the standard Go dependency management system, and as of Go 1.16 they are the default.

This PR adds a `go.mod` file so that Go Modules are supported by this project.