### PR TITLE
Change Event.PlayoffTypeString type to string

### DIFF
--- a/models.go
+++ b/models.go
@@ -103,7 +103,7 @@ type Event struct {
 	} `json:"webcasts"`
 	ParentEventKey    string `json:"parent_event_key"`
 	PlayoffType       int    `json:"playoff_type"`
-	PlayoffTypeString int    `json:"playoff_type_string"`
+	PlayoffTypeString string `json:"playoff_type_string"`
 }
 
 type awardsBuilder struct {


### PR DESCRIPTION
I'm not sure what changed on the TBA side, but when requesting the `2023isde1` event, I am getting JSON Unmarshal errors related to the `PlayoffTypeString` field.

This PR changes that field from an `int` to a `string` which is what I imagine it was supposed to be in the first place.